### PR TITLE
Tests written using JUnit and Mockito

### DIFF
--- a/src/Device.java
+++ b/src/Device.java
@@ -58,6 +58,10 @@ public class Device {
     private int state = 0;
 
     /**
+     * Accumulator for number of spins to do.
+     */
+    private int accumulator = 0;
+    /**
      * For testing, create a device and set its linear or polynomial turns relationship
      * @param initialBits the bit values for this test device
      * @param bitsPerPeek the number of bits to disclose via peek or set via poke
@@ -230,13 +234,13 @@ public class Device {
         if (all_false || all_true) return true;
         spins++;
         int i = 1;
-        if (random) numRotatesPerSpin = (int)(Math.random() * size);
-        while (i < numRotatesPerSpin % size) {
+        if (random) accumulator = (int)(Math.random() * size);
+        accumulator += spins * rotatesPerSpinMultiplier;
+        while (i < accumulator % size) {
             head = head.next;
             i++;
         }
         //System.out.println("spun " + (numRotatesPerSpin % size) + " times");
-        numRotatesPerSpin += spins * rotatesPerSpinMultiplier;
         //System.out.println(superPeek());
         return all_true || all_false;
     }
@@ -285,6 +289,7 @@ public class Device {
      * Poke bits into device.
      * @param pattern indicator of values of bits to poke
      */
+
     public void poke(CharSequence pattern) {
         if (state != STATE_PEEKED) return;
         state = STATE_POKED;

--- a/src/Device.java
+++ b/src/Device.java
@@ -1,0 +1,307 @@
+public class Device {
+    private Link<Character> head;
+    /**
+     * Whether or not we are using pseudo-random number generators for arbitrary rotations per spin
+     */
+    private boolean random = false;
+    /**
+     * Default number of bits to reveal per peek
+     */
+    public static final int DEFAULT_PEEKS = 2;
+    /**
+     * Default number of bits stored.
+     */
+    public static final int DEFAULT_SIZE = 4;
+    /**
+     * Character indicator of false.
+     */
+    public static final char VALUE_FALSE = 'F';
+    /**
+     * Character indicator of true.
+     */
+    public static final char VALUE_TRUE = 'T';
+    /**
+     * State indicating that this device was just spun.
+     */
+    private static final int STATE_SPUN = 1;
+    /**
+     * State indicating that this device was just peeked.
+     */
+    private static final int STATE_PEEKED = 2;
+    /**
+     * State indicating that this device was just poked.
+     */
+    private static final int STATE_POKED = 3;
+    /**
+     * The actual number of rotations that are done per spin.
+     */
+    private int numRotatesPerSpin = 1;
+    /**
+     * The increment multiplier for number of rotations per spin.
+     */
+    private int rotatesPerSpinMultiplier = 0;
+    /**
+     *  The number of bits we can peek
+     */
+    public int bitsPerPeek;
+    /**
+     * The number of spins that have been done
+     */
+    private int spins = 0;
+    /**
+     * The number of bits stored
+     */
+    public int size;
+    /**
+     * The current state of the device.
+     */
+    private int state = 0;
+
+    /**
+     * For testing, create a device and set its linear or polynomial turns relationship
+     * @param initialBits the bit values for this test device
+     * @param bitsPerPeek the number of bits to disclose via peek or set via poke
+     * @param numRotatesPerSpin number of times to rotate per spin
+     * @param rotatesPerSpinMultiplier a multiple we add to the numRotatesPerSpin each time spin is called to emulate polynomial rotations
+     */
+    public Device(boolean[] initialBits, int bitsPerPeek,  int numRotatesPerSpin, int rotatesPerSpinMultiplier) {
+        this(initialBits, bitsPerPeek);
+        this.numRotatesPerSpin = numRotatesPerSpin;
+        this.rotatesPerSpinMultiplier = rotatesPerSpinMultiplier;
+    }
+
+    /**
+     * For testing, create a device is either random or not, and with a numRotatesPerSpin rotations per spin, with rotatesPerSpinMultiplier polynomial rotations
+     * @param isRandom the number of bits to disclose via peek or set via poke
+     * @param numRotatesPerSpin number of times to rotate per spin
+     * @param rotatesPerSpinMultiplier a multiple we add to the numRotatesPerSpin each time spin is called to emulate polynomial rotations
+     */
+    public Device(boolean isRandom, int numRotatesPerSpin, int rotatesPerSpinMultiplier) {
+        this();
+        this.random = isRandom;
+        this.numRotatesPerSpin = numRotatesPerSpin;
+        this.rotatesPerSpinMultiplier = rotatesPerSpinMultiplier;
+    }
+    /**
+     * Construct device with specified bits for testing. Initial bit values are represented by an array of boolean primitives.
+     * @param initialBits the bit values for this test device
+     * @param bitsPerPeek the number of bits to disclose via peek or set via poke
+     */
+    public Device(boolean[] initialBits, int bitsPerPeek) {
+        createLinks(initialBits);
+        this.bitsPerPeek = bitsPerPeek;
+        this.size = initialBits.length;
+    }
+
+    /**
+     * Create a device that is pseudo random in rotations
+     * @param initialBits the bit values for this test device
+     * @param bitsPerPeek the number of bits to disclose via peek or set via poke
+     * @param isRandom whether or not this device uses pseudo-random rotations per spin
+     */
+    public Device(boolean[] initialBits, int bitsPerPeek, boolean isRandom) {
+        this(initialBits,bitsPerPeek);
+        this.random = isRandom;
+    }
+
+    /**
+     * Create a device with a choice of pseudo randomness
+     * @param isRandom whether or not to use pseudo-random rotations per spin
+     */
+    public Device(boolean isRandom) {
+        this();
+        this.random = isRandom;
+    }
+    /**
+     * Construct device with specified size and number of peek/poke bits.
+     * @param size the number of bits stored in this device
+     * @param bitsPerPeek the number of bits to disclose via peek or set via poke
+     */
+    public Device(int size, int bitsPerPeek) {
+        this.size = size;
+        boolean[] initialBits = new boolean[this.size];
+        for (int i = 0; i < size; i++) {
+            if (Math.random() > 0.5) initialBits[i] = true;
+        }
+        if (Math.random() > 0.5) rotatesPerSpinMultiplier = (int)(Math.random() * 10);
+        this.bitsPerPeek = bitsPerPeek;
+        setSpinner();
+        createLinks(initialBits);
+    }
+
+    /**
+     * Construct device using defaults.
+     */
+    public Device() {
+        this(DEFAULT_SIZE,DEFAULT_PEEKS);
+        setSpinner();
+    }
+
+    /**
+     * Create the linked list to store the bits used in the locking of this device.
+     * @param initialBits
+     */
+    private void createLinks(boolean[] initialBits) {
+        setSpinner();
+        if (initialBits.length < 1) return;
+        char firstValue = VALUE_FALSE;
+        if (initialBits[0]) firstValue = VALUE_TRUE;
+        Link first = new Link(firstValue);
+        Link last = first;
+        for (int i = 1; i < initialBits.length; i++) {
+            boolean bit = initialBits[i];
+            Link<Character> link = null;
+            if (bit) link = new Link<Character>(VALUE_TRUE);
+            else link = new Link<Character>(VALUE_FALSE);
+            last.add(link);
+            last = link;
+        }
+        last.add(first);
+        head = first;
+    }
+
+    /**
+     * Set the number of arbitrary spins for the next spin.
+     */
+    private void setSpinner() {
+        this.numRotatesPerSpin = (int)Math.round(Math.random() * size);
+        if (Math.random() > 0.5) rotatesPerSpinMultiplier = (int)Math.round(Math.random() * size);
+    }
+
+    /**
+     * Print out the bits of this device.
+     */
+    private void print() {
+        Link current = head;
+        System.out.print("[");
+        do {
+            System.out.print(current.data());
+            if (current.next != head) System.out.print(", ");
+            current = current.next;
+        } while (current != head);
+        System.out.println("]");
+    }
+
+    /**
+     * A string representing the bits in this device
+     * @return A string showign all bits in this device for testing.
+     */
+    protected String superPeek() {
+        Link current = head;
+        StringBuilder out = new StringBuilder("[");
+        do {
+            out.append(current.data());
+            if (current.next != head) out.append(", ");
+            current = current.next;
+        } while (current != head);
+        out.append("]");
+        return out.toString();
+    }
+
+    /**
+     * Render device information as a string.
+     * @return rendering that reveals partial state
+     */
+    @Override
+    public String toString() {
+        StringBuilder out = new StringBuilder();
+        out.append("Device[size: ");
+        out.append(size);
+        out.append(", bitsPerPeek: ");
+        out.append(bitsPerPeek);
+        out.append("]");
+        return out.toString();
+    }
+
+    /**
+     * Initiate device rotation.
+     * @return true if all bits have identical value; false otherwise
+     */
+    public boolean spin() {
+        state = STATE_SPUN;
+        boolean all_true = true;
+        boolean all_false = true;
+        Link current = head;
+        do {
+            if (current.data().equals(VALUE_TRUE)) all_false = false;
+            else if (current.data().equals(VALUE_FALSE)) all_true = false;
+            current = current.next;
+        } while (current != head);
+        if (all_false || all_true) return true;
+        spins++;
+        int i = 1;
+        if (random) numRotatesPerSpin = (int)(Math.random() * size);
+        while (i < numRotatesPerSpin % size) {
+            head = head.next;
+            i++;
+        }
+        //System.out.println("spun " + (numRotatesPerSpin % size) + " times");
+        numRotatesPerSpin += spins * rotatesPerSpinMultiplier;
+        //System.out.println(superPeek());
+        return all_true || all_false;
+    }
+
+    /**
+     * Deletes all occurrences of substring in StringBuilder
+     * @param q The StringBuilder instance to remove found substrings from
+     * @param what The substring to remove
+     */
+    private void del(StringBuilder q, String what) {
+        int f = -1;
+        while ((f = q.indexOf(what)) != -1) { q.delete(f,f +1); }
+    }
+
+    /**
+     * Peek at bits of device.
+     * @param pattern indicating which bits to show as '?'
+     * @return a pattern that discloses the values of the indicated bits
+     */
+    public CharSequence peek(CharSequence pattern) {
+        if (state != STATE_SPUN) return null;
+        state = STATE_PEEKED;
+        StringBuilder q = new StringBuilder(pattern);
+        int numPeeked = 0;
+        int f = -1;
+        del(q,"[");
+        del(q,"]");
+        del(q," ");
+        del(q,"\t");
+        Link c = head;
+        StringBuilder out = new StringBuilder("[");
+        for (int i = 0; i < q.length() && i < size; i++) {
+            if (numPeeked < bitsPerPeek && q.charAt(i) == '?') {
+                out.append(c.data());
+                numPeeked++;
+            }
+            else out.append("-");
+            if (i < size - 1) out.append(" ");
+            c = c.next;
+        }
+        out.append("]");
+        return out.toString();
+    }
+
+    /**
+     * Poke bits into device.
+     * @param pattern indicator of values of bits to poke
+     */
+    public void poke(CharSequence pattern) {
+        if (state != STATE_PEEKED) return;
+        state = STATE_POKED;
+        StringBuilder q = new StringBuilder(pattern);
+        int numPoked = 0;
+        int f = -1;
+        del(q,"[");
+        del(q,"]");
+        del(q," ");
+        del(q, "\t");
+        Link c = head;
+        for (int i = 0; i < q.length() && i < size; i++) {
+            if (numPoked < bitsPerPeek && (q.charAt(i) == VALUE_TRUE || q.charAt(i) == VALUE_FALSE)) {
+                numPoked++;
+                c.setData(q.charAt(i));
+            }
+            c = c.next;
+        }
+    }
+}

--- a/src/DeviceUnlocker.java
+++ b/src/DeviceUnlocker.java
@@ -1,0 +1,22 @@
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+public abstract class DeviceUnlocker {
+
+    /**
+     * Retrieve trace of previous unlock process.
+     * @return Rendering of steps in unlock process.
+     */
+    public static String showTrace() {
+        throw new NotImplementedException();
+    };
+
+    /**
+     * Unlocks a device-controlled resource.
+     * @param dev the device controlling the resource to unlock.
+     * @return true if the resource is unlocked (all bits are now identical); false otherwise
+     */
+    public static boolean unlock(Device dev) {
+        throw new NotImplementedException();
+    };
+
+}

--- a/src/Link.java
+++ b/src/Link.java
@@ -1,0 +1,42 @@
+public class Link<Type> {
+    /**
+     * The next link in this linked-list
+     */
+    protected Link next;
+    /**
+     * The data this link holds
+     */
+    private Type data;
+
+    /**
+     * Create a new link with data.
+     * @param data data to be stored in this link
+     */
+    protected Link(Type data) {
+        this.data = data;
+    }
+
+    /**
+     * Append a link to the end of this one.
+     * @param other the link to append
+     */
+    protected void add(Link other) {
+        next = other;
+    }
+
+    /**
+     * Retrieve the data stored in this link
+     * @return the data stored in this link
+     */
+    protected Type data() {
+        return this.data;
+    }
+
+    /**
+     * Set the data in this link
+     * @param data the data in this link
+     */
+    protected void setData(Type data) {
+        this.data = data;
+    }
+}

--- a/test/DeviceTest.java
+++ b/test/DeviceTest.java
@@ -1,0 +1,84 @@
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.Invocation;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.mockito.Mockito.spy;
+
+public class DeviceTest {
+    @Test
+    public void linearTest() {
+        boolean[] initialBits = {true,true,false,true};
+        for (int i = 0; i < initialBits.length * 2; i++) {
+            Device dev = new Device(initialBits,2,i,0);
+            for (int k = 0; k < initialBits.length; k++) {
+                dev.spin();
+            }
+            Field spins = null;
+            try {
+                spins = dev.getClass().getDeclaredField("spins");
+                spins.setAccessible(true);
+                if (spins != null) System.out.println("spins: " + spins.getInt(dev));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            System.out.println(dev.superPeek());
+            assert(dev.superPeek().equals("[T, T, F, T]"));
+        }
+    }
+    @Test
+    public void polynomialTest() {
+        boolean[] initialBits = {true,true,false,true};
+        boolean somePolynomialSpinsDoNotResetAfterSizeSpins = false;
+        for (int i = 2; i < initialBits.length * 2; i++) {
+            for (int j = 2; j < initialBits.length * 2; j++) {
+                if (j % 5 != 0) {
+                    System.out.println(i + ", " + j);
+                    Device dev = new Device(initialBits, 2, i, j);
+                    for (int k = 0; k < 5; k++) {
+                        dev.spin();
+                    }
+                    Field spins = null;
+                    try {
+                        spins = dev.getClass().getDeclaredField("spins");
+                        spins.setAccessible(true);
+                        if (spins != null) System.out.println("spins: " + spins.getInt(dev));
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    System.out.println(dev.superPeek());
+                    if (!dev.superPeek().equals("[T, T, F, T]")) somePolynomialSpinsDoNotResetAfterSizeSpins = true;
+                }
+            }
+        }
+        assert(somePolynomialSpinsDoNotResetAfterSizeSpins);
+    }
+    @Test
+    public void randomTest() {
+        boolean[] initialBits = {true,true,false,true};
+        ArrayList<String> possibleConfigurations = new ArrayList<String>();
+        possibleConfigurations.add("[T, T, F, T]");
+        possibleConfigurations.add("[T, F, T, T]");
+        possibleConfigurations.add("[F, T, T, T]");
+        possibleConfigurations.add("[T, T, T, F]");
+        Device dev = new Device(initialBits,2,true);
+        dev.spin();
+        int lastIndex = possibleConfigurations.indexOf(dev.superPeek());
+        ArrayList<Integer> offsets = new ArrayList<Integer>();
+        for (int i = 0; i < 1000; i++) {
+            dev.spin();
+            int offset = Math.abs(lastIndex - possibleConfigurations.indexOf(dev.superPeek()));
+            offset = offset % 4;
+            if (!offsets.contains(offset)) offsets.add(offset);
+            lastIndex = possibleConfigurations.indexOf(dev.superPeek());
+        }
+        assert(offsets.size() > 1);
+    }
+    @Test
+    public void nullDeviceTest() {
+        FourBitTwoDisclosureDeviceUnlocker.unlock(null);
+    }
+}

--- a/test/DeviceTest.java
+++ b/test/DeviceTest.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static junit.framework.TestCase.fail;
 import static org.mockito.Mockito.spy;
 
 public class DeviceTest {
@@ -24,6 +25,7 @@ public class DeviceTest {
                 if (spins != null) System.out.println("spins: " + spins.getInt(dev));
             } catch (Exception e) {
                 e.printStackTrace();
+                fail();
             }
             System.out.println(dev.superPeek());
             assert(dev.superPeek().equals("[T, T, F, T]"));
@@ -33,9 +35,8 @@ public class DeviceTest {
     public void polynomialTest() {
         boolean[] initialBits = {true,true,false,true};
         boolean somePolynomialSpinsDoNotResetAfterSizeSpins = false;
-        for (int i = 2; i < initialBits.length * 2; i++) {
-            for (int j = 2; j < initialBits.length * 2; j++) {
-                if (j % 5 != 0) {
+        for (int i = 1; i < initialBits.length * 2; i++) {
+            for (int j = 1; j < initialBits.length * 2; j++) {
                     System.out.println(i + ", " + j);
                     Device dev = new Device(initialBits, 2, i, j);
                     for (int k = 0; k < 5; k++) {
@@ -47,12 +48,12 @@ public class DeviceTest {
                         spins.setAccessible(true);
                         if (spins != null) System.out.println("spins: " + spins.getInt(dev));
                     } catch (Exception e) {
+                        fail();
                         e.printStackTrace();
                     }
                     System.out.println(dev.superPeek());
                     if (!dev.superPeek().equals("[T, T, F, T]")) somePolynomialSpinsDoNotResetAfterSizeSpins = true;
                 }
-            }
         }
         assert(somePolynomialSpinsDoNotResetAfterSizeSpins);
     }
@@ -75,10 +76,7 @@ public class DeviceTest {
             if (!offsets.contains(offset)) offsets.add(offset);
             lastIndex = possibleConfigurations.indexOf(dev.superPeek());
         }
+        System.out.println(offsets);
         assert(offsets.size() > 1);
-    }
-    @Test
-    public void nullDeviceTest() {
-        FourBitTwoDisclosureDeviceUnlocker.unlock(null);
     }
 }

--- a/test/FourBitTwoDisclosureDeviceUnlockerTest.java
+++ b/test/FourBitTwoDisclosureDeviceUnlockerTest.java
@@ -1,0 +1,61 @@
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class FourBitTwoDisclosureDeviceUnlockerTest {
+    @Test
+    /**
+     * Ensures that the trace is showing accurate information.
+     */
+    public void traceTest() {
+        Device dev = spy(Device.class);
+        FourBitTwoDisclosureDeviceUnlocker.unlock(dev);
+        StringBuilder stringBuilder = new StringBuilder(FourBitTwoDisclosureDeviceUnlocker.showTrace());
+        // chop off the brackets
+        String test = stringBuilder.substring(1,stringBuilder.length() - 1);
+        // split it by comma
+        String[] split = test.split(", ");
+
+        int spins, pokes, peeks;
+        spins = pokes = peeks = 0;
+        for (String atom : split) {
+            if (atom.startsWith("spin")) spins++;
+            else if (atom.startsWith("poke")) pokes++;
+            else if (atom.startsWith("peek")) peeks++;
+        }
+        // times spin was called matches trace
+        verify(dev,times(spins)).spin();
+        // times peek was called matches trace
+        verify(dev,times(peeks)).peek(any());
+        // times pokes was called matches trace
+        verify(dev,times(pokes)).poke(any());
+    }
+
+    @Test(timeout=1000)
+    /**
+     * unlock should halt/finish within 1/10th of a second.
+     */
+    public void heuristicHaltingTest() {
+        for (int i = 0; i < 10; i++) {
+            Device dev = new Device();
+            FourBitTwoDisclosureDeviceUnlocker.unlock(dev);
+        }
+    }
+    @Test
+    /**
+     * This should test for 99% efficiency in unlocking all 3 kinds of devices: linear, polynomial, and random rotations.
+     */
+    public void efficiencyTest() {
+        int successes = 0;
+        for (int i = 0; i < 1000; i++) {
+            Device dev = null;
+            if (i % 3 == 0) dev = new Device();
+            else if (i % 3 == 1) dev = new Device(true);
+            else if (i % 3 == 2) dev = new Device(false, (int)(Math.random() * 4), (int)(Math.random() * 10));
+            if (FourBitTwoDisclosureDeviceUnlocker.unlock(dev)) successes++;
+            else System.out.println(dev + ": " + dev.superPeek());
+        }
+        System.out.println(successes);
+        assert(successes > 1000 * 0.99);
+    }
+}

--- a/test/FourBitTwoDisclosureDeviceUnlockerTest.java
+++ b/test/FourBitTwoDisclosureDeviceUnlockerTest.java
@@ -4,6 +4,11 @@ import static org.mockito.Mockito.*;
 
 public class FourBitTwoDisclosureDeviceUnlockerTest {
     @Test
+    public void nullDeviceTest() {
+        FourBitTwoDisclosureDeviceUnlocker.unlock(null);
+    }
+
+    @Test
     /**
      * Ensures that the trace is showing accurate information.
      */


### PR DESCRIPTION

**I am available for code review with anyone interested Today (Wednesday, September 6th, 2017) at 4pm to 6pm. After today, please email me to set up a time for code review. Thanks!**


Here are some implemented java files for `Device`  class and `DeviceUnlocker` abstract class, as well as some tests to help us implement a working version of `FourBitTwoDisclosureDeviceUnlocker.java`.

This first commit makes a bunch of assumptions to the following questions we must clarify for **requirements**:
- What format of CharSequence does 'pattern' come in for `Device.java`'s ``peek(CharSequence pattern)`` and ``poke(CharSequence pattern)``?
-- Should we ignore anything but T or F? Or should we throw exceptions if it is not following a precise format?
-- Do we include the []'s in the CharSequence that the documentation describes?
-- Do we delimit by space? And/Or tab? And/Or new lines? And/Or 
- Can we only ``poke(CharSequence pattern)`` using specified positions of bits that we asked for in the preceding ``peek(CharSequence pattern)``?
- Should showTrace() follow a precise format?
-- Would the customer like to have the method calls ``peek``, ``poke``, and ``spin`` be listed in the ``showTrace()``? What a bout the ``charSequence`` parameters that some of these methods require?
-- What would help the customer and make the customer happy for showTrace()?
- Do we have access to any fields or methods that will tell us how many bits are being held by the Device?
-- Should we just assume it will always be 4 bits, since the class we are delivering is named "**FourBitTwoDisclosureDeviceUnlocker.java**"?
-- Are we always going to have 2 disclosed bits for ``peek`` and ``poke``? If not, how do we find out this number?
-- In that same vein, will our implementation be creating new `Device` objects?
- How efficient does the implemented ``unlock(Device dev)`` method need to be?
-- Does it need to be efficient as possible, and call the least number of ``spin``, ``peek``, and ``poke`` methods as possible?
-- How efficient should our implementation be? Should it have over 99% success rate in unlocking devices?
-- What is our execution time limit?


**The _assumptions_ to these questions in this commit are:**
- The format expected from a `CharSequence` returned by the method ``peek`` are as follows: A CharSequence starting with a ``[`` character, immediately followed by TRUE or FALSE characters delimited by a single space character `` ``, specified by the device as ``T`` or ``F``, respectively, and appended at the end with a final ``]`` character. The format is not enforced, and the implementation must only parse the needed information. The information that must be true and valid is the order in which the bits are represented for the current ``spin``: The first TRUE or FALSE value represents the first bit represented in this rotation from the previous ``spin``, followed by the next TRUE or FALSE values in order as they appear. For example, for a 4 bit, 2 disclosed Device to be unlocked, the following format for a `CharSequence` is valid: ``[T F - -]``
- The format expected for a ``peek`` method are as follows: A `CharSequence` starting with a ``[`` character, immediately followed by one of the following characters, delimited by a space: ``?`` and  ``-``, appended at the end with a final ``]`` character. Any ``?`` characters that go over the number that the field ``bitsPerPeek`` represents are ignored.
- The format expected for a ``poke`` method are as follows: A `CharSequence` starting with a ``[`` character, immediately followed by one of the following characters, delimited by a space: ``T``, ``F``, and ``-``, finally appended at the end with a ``]``. Any extra ``T`` or ``F`` characters beyond the ``bitsPerPeek`` field represent are ignored.
- We do have access to a field ``public int size`` in Device that represents the number of bits the Device is holding, as well as a field ``public int bitsPerPeek`` that represents the number of bits disclosed by a ``peek`` method.
- You can poke valid locations in the current rotation resulting from the previous ``spin``, even if they are not what you requested in your previous ``peek`` call.
- ``showTrace()`` returns a string in this format: a String beginning with a ``[`` character, immediately followed by the first method (out of ``spin``, ``peek``, and ``poke``) called on `Device dev`, followed in order as they are called, the following methods called on `Device dev`, delimited by a comma, followed by a space (``, ``). The ``poke`` and ``peek`` commands are immediately followed by a colon character followed by a space (``:` `), and then the `CharSequence` that was used in the method called. Finally, at the end is appended a single ``]`` character. The ``showTrace()`` should show exactly the methods called, in order, to attempt to unlock the resource that `Device dev` holds, even if it is unsuccessful.
- You cannot assume it will always be 4 bits of boolean data with 2 disclosed bits at any given ``spin``. Instead, there may be *Devices* that have 1 to N bits, and 1 to N disclosed  bits.
- Efficiency does take priority, in the form of a *heuristical success* as follows: The device must be unlocked within a second, or fail. It does not matter how many methods are called in this execution time, or in what order.
- The excution time limit is around 1/10th of a second.


**Notes:**
I have decided that we should implement our own "mock" version of `Device.java` and `DeviceUnlocker.java` in case the customer is too busy to provide us with working .class files. This will help curb risk involving the customer being unhappy with us not meeting requirements when they could be inferred. Implementing these classes have also helped us realize what questions we might have for the stakeholders in what our approach should be, and what matters most in our product delivery.