### PR TITLE
Matched implementation of mock Device.java to requirements

### DIFF
--- a/src/Device.java
+++ b/src/Device.java
@@ -5,7 +5,7 @@ public class Device {
     /**
      * A list of requested positions from the last peek method
      */
-    private ArrayList<Integer> requestedPositions;
+    private List<Integer> requestedPositions;
     /**
      * Whether or not we are using pseudo-random number generators for arbitrary rotations per spin
      */

--- a/test/FourBitTwoDisclosureDeviceUnlockerTest.java
+++ b/test/FourBitTwoDisclosureDeviceUnlockerTest.java
@@ -24,6 +24,7 @@ public class FourBitTwoDisclosureDeviceUnlockerTest {
         int spins, pokes, peeks;
         spins = pokes = peeks = 0;
         for (String atom : split) {
+            System.out.println(atom);
             if (atom.startsWith("spin")) spins++;
             else if (atom.startsWith("poke")) pokes++;
             else if (atom.startsWith("peek")) peeks++;


### PR DESCRIPTION
as given by stakeholder:

- peek and poke CharSequences must be exactly as long as the number of bits held by the Device. Will throw an IllegalArgumentException in our mock implementation to avoid unspecified behavior in the real world.
- peek method in mocked Device.java implementation now returns a CharSequence exactly as long as the number of bits held by device instance.