### PR TITLE
Feature/testing

### DIFF
--- a/test/FourBitTwoDisclosureDeviceUnlockerTest.java
+++ b/test/FourBitTwoDisclosureDeviceUnlockerTest.java
@@ -15,7 +15,7 @@ public class FourBitTwoDisclosureDeviceUnlockerTest {
     public void traceTest() {
         Device dev = spy(Device.class);
         FourBitTwoDisclosureDeviceUnlocker.unlock(dev);
-        // split it by comma
+        // split by new line character
         String[] split = FourBitTwoDisclosureDeviceUnlocker.showTrace().split("\n");
 
         int spins, pokes, peeks;

--- a/test/FourBitTwoDisclosureDeviceUnlockerTest.java
+++ b/test/FourBitTwoDisclosureDeviceUnlockerTest.java
@@ -15,16 +15,12 @@ public class FourBitTwoDisclosureDeviceUnlockerTest {
     public void traceTest() {
         Device dev = spy(Device.class);
         FourBitTwoDisclosureDeviceUnlocker.unlock(dev);
-        StringBuilder stringBuilder = new StringBuilder(FourBitTwoDisclosureDeviceUnlocker.showTrace());
-        // chop off the brackets
-        String test = stringBuilder.substring(1,stringBuilder.length() - 1);
         // split it by comma
-        String[] split = test.split(", ");
+        String[] split = FourBitTwoDisclosureDeviceUnlocker.showTrace().split("\n");
 
         int spins, pokes, peeks;
         spins = pokes = peeks = 0;
         for (String atom : split) {
-            System.out.println(atom);
             if (atom.startsWith("spin")) spins++;
             else if (atom.startsWith("poke")) pokes++;
             else if (atom.startsWith("peek")) peeks++;


### PR DESCRIPTION
I have now enforced that each listing in the `showTrace` method be delimited by new line characters.

I have removed the loose enforcement of encapsulating brackets at the beginning and end of the showTrace returned string.

The test still verifies that the listed method calls in showTrace are performed the exact number of times as it says, for integrity.

It assumes that the names for the listings are one of three:
- spin
- peek
- poke
It only enforces that the listings verified are starting with one of these substrings.